### PR TITLE
feat: sonar coverage exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,13 @@
     <lombok.version>1.18.12</lombok.version>
     <liquibase.version>3.9.0</liquibase.version>
     <springdoc.version>1.3.9</springdoc.version>
+    <guava.version>29.0-jre</guava.version>
     <!-- plugins -->
     <plugin.checkstyle.version>3.1.1</plugin.checkstyle.version>
     <plugin.sonar.version>3.6.1.1688</plugin.sonar.version>
     <plugin.jacoco.version>0.8.5</plugin.jacoco.version>
-    <guava.version>29.0-jre</guava.version>
+    <!-- sonar -->
+    <sonar.coverage.exclusions>**/config/*,**/exception/*,**/entity/*,**/model/*</sonar.coverage.exclusions>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/app/coronawarn/testresult/TestResultRepository.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultRepository.java
@@ -21,6 +21,7 @@
 
 package app.coronawarn.testresult;
 
+import app.coronawarn.testresult.entity.TestResultEntity;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/app/coronawarn/testresult/TestResultService.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultService.java
@@ -21,6 +21,7 @@
 
 package app.coronawarn.testresult;
 
+import app.coronawarn.testresult.entity.TestResultEntity;
 import app.coronawarn.testresult.exception.TestResultException;
 import app.coronawarn.testresult.model.TestResult;
 import java.time.LocalDateTime;

--- a/src/main/java/app/coronawarn/testresult/entity/TestResultEntity.java
+++ b/src/main/java/app/coronawarn/testresult/entity/TestResultEntity.java
@@ -19,7 +19,7 @@
  * under the License.
  */
 
-package app.coronawarn.testresult;
+package app.coronawarn.testresult.entity;
 
 import java.time.LocalDateTime;
 import javax.persistence.Column;

--- a/src/test/java/app/coronawarn/testresult/TestResultCleanupTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultCleanupTest.java
@@ -1,5 +1,6 @@
 package app.coronawarn.testresult;
 
+import app.coronawarn.testresult.entity.TestResultEntity;
 import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.Optional;

--- a/src/test/java/app/coronawarn/testresult/TestResultRepositoryTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultRepositoryTest.java
@@ -21,6 +21,7 @@
 
 package app.coronawarn.testresult;
 
+import app.coronawarn.testresult.entity.TestResultEntity;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.Assert;


### PR DESCRIPTION
We should exclude the simple config, exception, model and entity classes from business logic test coverage.