### PR TITLE
fix: return pending test result if not found

### DIFF
--- a/src/main/java/app/coronawarn/testresult/TestResultController.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultController.java
@@ -62,7 +62,7 @@ public class TestResultController {
   public ResponseEntity<TestResultResponse> result(
     @RequestBody @Valid TestResultRequest request
   ) {
-    TestResult result = testResultService.get(request.getId());
+    TestResult result = testResultService.getOrCreate(request.getId());
     return ResponseEntity.ok(new TestResultResponse()
       .setTestResult(result.getResult() == null ? 0 : result.getResult()));
   }

--- a/src/main/java/app/coronawarn/testresult/TestResultService.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultService.java
@@ -25,6 +25,7 @@ import app.coronawarn.testresult.entity.TestResultEntity;
 import app.coronawarn.testresult.exception.TestResultException;
 import app.coronawarn.testresult.model.TestResult;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -60,7 +61,8 @@ public class TestResultService {
         .setId(entity.getResultId())
         .setResult(entity.getResult());
     } catch (Exception e) {
-      throw new TestResultException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to insert or update test result.");
+      throw new TestResultException(HttpStatus.INTERNAL_SERVER_ERROR,
+        "Failed to insert or update test result.");
     }
   }
 
@@ -70,12 +72,17 @@ public class TestResultService {
    * @param id the test result id
    * @return the test result
    */
-  public TestResult get(String id) {
-    TestResultEntity entity = testResultRepository.findByResultId(id)
-      .orElseThrow(() -> new TestResultException(HttpStatus.NOT_FOUND, "Test result not found."));
-    return new TestResult()
-      .setId(entity.getResultId())
-      .setResult(entity.getResult());
+  public TestResult getOrCreate(String id) {
+    Optional<TestResultEntity> entity = testResultRepository.findByResultId(id);
+    if (entity.isPresent()) {
+      return new TestResult()
+        .setId(entity.get().getResultId())
+        .setResult(entity.get().getResult());
+    } else {
+      return insertOrUpdate(new TestResult()
+        .setId(id)
+        .setResult(0));
+    }
   }
 
 }

--- a/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
@@ -122,4 +122,25 @@ public class TestResultControllerTest {
       .andExpect(MockMvcResultMatchers.status().isOk());
   }
 
+  @Test
+  public void notExisitingTestResultShouldReturnOk() throws Exception {
+    // data
+    String id = "b".repeat(64);
+    Integer result = 1;
+    // create
+    List<TestResult> valid = Collections.singletonList(
+      new TestResult().setId(id).setResult(result)
+    );
+    // get
+    TestResultRequest request = new TestResultRequest()
+      .setId(id);
+    mockMvc.perform(MockMvcRequestBuilders
+      .post("/api/v1/app/result")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+      .contentType(MediaType.APPLICATION_JSON_VALUE)
+      .content(objectMapper.writeValueAsString(request)))
+      .andDo(MockMvcResultHandlers.print())
+      .andExpect(MockMvcResultMatchers.status().isOk());
+  }
+
 }

--- a/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
@@ -63,7 +63,7 @@ public class TestResultServiceTest {
     Assert.assertNotNull(testResult);
     Assert.assertEquals(result, testResult.getResult());
     // get
-    testResult = testResultService.get(id);
+    testResult = testResultService.getOrCreate(id);
     Assert.assertNotNull(testResult);
     Assert.assertEquals(result, testResult.getResult());
   }
@@ -74,8 +74,9 @@ public class TestResultServiceTest {
     String id = "b".repeat(64);
     // get
     try {
-      testResultService.get(id);
-      Assert.fail();
+      //should always return pending test result
+      //testResultService.get(id);
+      //Assert.fail();
     } catch (TestResultException e) {
       Assert.assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
     }


### PR DESCRIPTION
The service should return test results with state pending (0) for unknown ids also.
This default test result will also be persisted.