### PR TITLE
refactor/proper-controller-tests

### DIFF
--- a/src/main/java/app/coronawarn/testresult/TestResultApplication.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultApplication.java
@@ -24,13 +24,11 @@ package app.coronawarn.testresult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 @Slf4j
 @EnableScheduling
-@EnableJpaAuditing
 @EnableWebSecurity
 @SpringBootApplication
 public class TestResultApplication {

--- a/src/main/java/app/coronawarn/testresult/config/JpaAuditConfig.java
+++ b/src/main/java/app/coronawarn/testresult/config/JpaAuditConfig.java
@@ -1,0 +1,12 @@
+package app.coronawarn.testresult.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+
+
+}

--- a/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
@@ -21,153 +21,361 @@
 
 package app.coronawarn.testresult;
 
+import app.coronawarn.testresult.exception.TestResultException;
 import app.coronawarn.testresult.model.TestResult;
 import app.coronawarn.testresult.model.TestResultRequest;
+import app.coronawarn.testresult.model.TestResultResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
-@ContextConfiguration(classes = TestResultApplication.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest(TestResultController.class)
 public class TestResultControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
-  @Autowired
-  private ObjectMapper objectMapper;
-  @Autowired
-  private TestResultRepository testResultRepository;
+
+  private JacksonTester<List<TestResult>> jsonTestResult;
+  private JacksonTester<TestResultRequest> jsonTestResultRequest;
+  private JacksonTester<TestResultResponse> jsonTestResultResponse;
+
+  @MockBean
+  private TestResultService testResultService;
 
   @Before
   public void before() {
-    testResultRepository.deleteAll();
+    JacksonTester.initFields(this, new ObjectMapper());
+  }
+
+  // ### results path ###
+  @Test
+  public void results_insertTestResultWithEmptyId_resultingInBadRequest() throws Exception {
+    String emptyId = "";
+    Integer validTestResultValue = 1;
+    TestResult validTestResult = new TestResult().setId(emptyId).setResult(validTestResultValue);
+    List<TestResult> invalidTestResults = Collections.singletonList(validTestResult);
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/lab/results")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResult.write(invalidTestResults).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isBadRequest())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.never()).insertOrUpdate(Mockito.any());
   }
 
   @Test
-  public void insertInvalidShouldReturnBadRequest() throws Exception {
-    // data
-    String id = "";
-    Integer result = 0;
-    // create
-    List<TestResult> invalid = Collections.singletonList(
-      new TestResult().setId("").setResult(0)
-    );
-    mockMvc.perform(MockMvcRequestBuilders
-      .post("/api/v1/lab/results")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(objectMapper.writeValueAsString(invalid)))
-      .andDo(MockMvcResultHandlers.print())
-      .andExpect(MockMvcResultMatchers.status().isBadRequest());
+  public void results_insertTestResultWithOutOfRangeTestResultValue_resultingInBadRequest()
+    throws Exception {
+    String validId = "a".repeat(64);
+    Integer outOfRangeTestResult = 0;
+    TestResult validTestResult = new TestResult().setId(validId).setResult(outOfRangeTestResult);
+    List<TestResult> invalidTestResults = Collections.singletonList(validTestResult);
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/lab/results")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResult.write(invalidTestResults).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isBadRequest())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.never()).insertOrUpdate(Mockito.any());
   }
 
   @Test
-  public void insertValidShouldReturnNoContent() throws Exception {
-    // data
-    String id = "a".repeat(64);
-    Integer result = 1;
-    // create
-    List<TestResult> valid = Collections.singletonList(
-      new TestResult().setId(id).setResult(result)
-    );
-    mockMvc.perform(MockMvcRequestBuilders
-      .post("/api/v1/lab/results")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(objectMapper.writeValueAsString(valid)))
-      .andDo(MockMvcResultHandlers.print())
-      .andExpect(MockMvcResultMatchers.status().isNoContent());
+  public void results_insertTestResultWithIdPatternNotMatching_resultingInBadRequest()
+    throws Exception {
+    String idPatternNotMatching = "a";
+    Integer validTestResultValue = 1;
+    TestResult validTestResult = new TestResult().setId(idPatternNotMatching)
+      .setResult(validTestResultValue);
+    List<TestResult> invalidTestResults = Collections.singletonList(validTestResult);
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/lab/results")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResult.write(invalidTestResults).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isBadRequest())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.never()).insertOrUpdate(Mockito.any());
   }
 
   @Test
-  public void insertValidAndGetShouldReturnOk() throws Exception {
-    // data
-    String id = "b".repeat(64);
-    Integer result = 1;
-    // create
-    List<TestResult> valid = Collections.singletonList(
-      new TestResult().setId(id).setResult(result)
-    );
-    mockMvc.perform(MockMvcRequestBuilders
-      .post("/api/v1/lab/results")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(objectMapper.writeValueAsString(valid)))
-      .andDo(MockMvcResultHandlers.print())
-      .andExpect(MockMvcResultMatchers.status().isNoContent());
-    // get
-    TestResultRequest request = new TestResultRequest()
-      .setId(id);
-    mockMvc.perform(MockMvcRequestBuilders
-      .post("/api/v1/app/result")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(objectMapper.writeValueAsString(request)))
-      .andDo(MockMvcResultHandlers.print())
-      .andExpect(MockMvcResultMatchers.status().isOk());
+  public void results_insertTestResultWithNoTestResultValue_resultingInCreatingEntity()
+    throws Exception {
+    String validId = "a".repeat(64);
+    Integer nullingTestResult = null;
+    TestResult validTestResult = new TestResult().setId(validId).setResult(nullingTestResult);
+    List<TestResult> invalidTestResults = Collections.singletonList(validTestResult);
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/lab/results")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResult.write(invalidTestResults).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isNoContent())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.times(1)).insertOrUpdate(Mockito.any());
   }
 
   @Test
-  public void insertValidPendingAndGetShouldReturnOk() throws Exception {
-    // data
-    String id = "b".repeat(64);
-    // create
-    List<TestResult> valid = Collections.singletonList(
-      new TestResult().setId(id)
-    );
-    mockMvc.perform(MockMvcRequestBuilders
-      .post("/api/v1/lab/results")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(objectMapper.writeValueAsString(valid)))
-      .andDo(MockMvcResultHandlers.print())
-      .andExpect(MockMvcResultMatchers.status().isNoContent());
-    // get
-    TestResultRequest request = new TestResultRequest()
-      .setId(id);
-    mockMvc.perform(MockMvcRequestBuilders
-      .post("/api/v1/app/result")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(objectMapper.writeValueAsString(request)))
-      .andDo(MockMvcResultHandlers.print())
-      .andExpect(MockMvcResultMatchers.status().isOk());
+  public void results_insertEmptyTestResultList_resultingInBadRequest() throws Exception {
+    List<TestResult> emptyTestResults = Collections.emptyList();
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/lab/results")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResult.write(emptyTestResults).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isBadRequest())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.never()).insertOrUpdate(Mockito.any());
   }
 
   @Test
-  public void notExistingTestResultShouldReturnOk() throws Exception {
-    // data
-    String id = "b".repeat(64);
-    Integer result = 1;
-    // create
-    List<TestResult> valid = Collections.singletonList(
-      new TestResult().setId(id).setResult(result)
-    );
-    // get
-    TestResultRequest request = new TestResultRequest()
-      .setId(id);
-    mockMvc.perform(MockMvcRequestBuilders
-      .post("/api/v1/app/result")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(objectMapper.writeValueAsString(request)))
-      .andDo(MockMvcResultHandlers.print())
-      .andExpect(MockMvcResultMatchers.status().isOk());
+  public void results_insertWithoutRequestBody_resultingInBadRequest() throws Exception {
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/lab/results")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE))
+      .andExpect(MockMvcResultMatchers.status().isBadRequest())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.never()).insertOrUpdate(Mockito.any());
+  }
+
+  @Test
+  public void results_insertWrongContentType_resultingInUnsupportedMediaType() throws Exception {
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/lab/results")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_XML_VALUE)
+          .content("fake xml since it does not get picked up."))
+      .andExpect(MockMvcResultMatchers.status().isUnsupportedMediaType())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.never()).insertOrUpdate(Mockito.any());
+  }
+
+  @Test
+  public void results_ServiceThrowingTestResultException_resultingInInternalServerError()
+    throws Exception {
+    String validId = "a".repeat(64);
+    Integer validTestResultValue = 1;
+    TestResult validTestResult = new TestResult().setId(validId).setResult(validTestResultValue);
+    List<TestResult> invalidTestResults = Collections.singletonList(validTestResult);
+    BDDMockito
+      .given(testResultService.insertOrUpdate(BDDMockito.any()))
+      .willThrow(new TestResultException(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "Failed to insert or update test result."
+      ));
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/lab/results")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResult.write(invalidTestResults).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isInternalServerError())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+    BDDMockito.verify(testResultService, Mockito.times(1))
+      .insertOrUpdate(validTestResult);
+  }
+
+  @Test
+  public void results_insertValidTestResult_proceedsCorrectly() throws Exception {
+    String validId = "a".repeat(64);
+    Integer validTestResultValue = 2;
+    TestResult validTestResult = new TestResult().setId(validId).setResult(validTestResultValue);
+    List<TestResult> invalidTestResults = Collections.singletonList(validTestResult);
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/lab/results")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResult.write(invalidTestResults).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isNoContent())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.times(1))
+      .insertOrUpdate(validTestResult);
+  }
+
+  //### result path ###
+  @Test
+  public void result_invalidTestResultRequest_proceedsCorrectly() {
+    String invalidIdPattern = "a".repeat(63);
+    String nullId = null;
+    String whitespaceId = StringUtils.SPACE;
+    List<TestResultRequest> invalidTestRequests =
+      Stream.of(invalidIdPattern, nullId, whitespaceId)
+        .map(string -> new TestResultRequest().setId(string))
+        .collect(Collectors.toList());
+
+    invalidTestRequests.forEach(this::performMockMvcWithTryCatch);
+    BDDMockito.verify(testResultService, Mockito.never()).getOrInsert(Mockito.any());
+  }
+
+  @Test
+  public void result_validTestResultRequestNotInDatabase_resultingOk() throws Exception {
+    String validId = "a".repeat(64);
+    TestResultRequest validTestRequest = new TestResultRequest().setId(validId);
+    Integer testResultNotConfirmed = 0;
+    TestResult validTestResult = new TestResult().setId(validId).setResult(testResultNotConfirmed);
+    BDDMockito.given(testResultService.getOrInsert(validId)).willReturn(validTestResult);
+    TestResultResponse resultResponse = new TestResultResponse()
+      .setTestResult(testResultNotConfirmed);
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/app/result")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResultRequest.write(validTestRequest).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isOk())
+      .andExpect(MockMvcResultMatchers.content()
+        .string(jsonTestResultResponse.write(resultResponse).getJson()))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.times(1)).getOrInsert(Mockito.any());
+  }
+
+  @Test
+  public void result_validTestResultRequestWithNoTestResultConfirmationYet_returnsTestResultResponse()
+    throws Exception {
+    String validId = "a".repeat(64);
+    TestResultRequest validTestRequest = new TestResultRequest().setId(validId);
+    Integer testResultNotConfirmed = 0;
+    TestResult validTestResult = new TestResult().setId(validId).setResult(testResultNotConfirmed);
+    BDDMockito.given(testResultService.getOrInsert(validId)).willReturn(validTestResult);
+    TestResultResponse resultResponse =
+      new TestResultResponse().setTestResult(testResultNotConfirmed);
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/app/result")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResultRequest.write(validTestRequest).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isOk())
+      .andExpect(MockMvcResultMatchers.content()
+        .string(jsonTestResultResponse.write(resultResponse).getJson()))
+      .andDo(MockMvcResultHandlers.print());
+  }
+
+  @Test
+  public void result_validTestResultRequestWithPositiveTestResult_returnsPositiveTestResultResponse()
+    throws Exception {
+    String validId = "a".repeat(64);
+    TestResultRequest validTestRequest = new TestResultRequest().setId(validId);
+    Integer positiveTestResult = 2;
+    TestResult validTestResult = new TestResult().setId(validId).setResult(positiveTestResult);
+    BDDMockito.given(testResultService.getOrInsert(validId)).willReturn(validTestResult);
+    TestResultResponse resultResponse = new TestResultResponse().setTestResult(positiveTestResult);
+
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/app/result")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .content(jsonTestResultRequest.write(validTestRequest).getJson()))
+      .andExpect(MockMvcResultMatchers.status().isOk())
+      .andExpect(MockMvcResultMatchers.content()
+        .string(jsonTestResultResponse.write(resultResponse).getJson()))
+      .andDo(MockMvcResultHandlers.print());
+  }
+
+  @Test
+  public void result_testResultRequestWithoutBody_resultingInBadRequest() throws Exception {
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/app/result")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_JSON_VALUE))
+      .andExpect(MockMvcResultMatchers.status().isBadRequest())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.never()).getOrInsert(Mockito.any());
+  }
+
+  @Test
+  public void result_testResultRequestWithWrongContentType_resultingInUnsupportedMediaType()
+    throws Exception {
+    mockMvc
+      .perform(
+        MockMvcRequestBuilders.post("/api/v1/app/result")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+          .contentType(MediaType.APPLICATION_XML_VALUE)
+          .content("fake xml since it does not get picked up."))
+      .andExpect(MockMvcResultMatchers.status().isUnsupportedMediaType())
+      .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+      .andDo(MockMvcResultHandlers.print());
+
+    BDDMockito.verify(testResultService, Mockito.never()).getOrInsert(Mockito.any());
+  }
+
+  // ### H E L P E R ###
+  private void performMockMvcWithTryCatch(TestResultRequest request) {
+    try {
+      mockMvc
+        .perform(
+          MockMvcRequestBuilders.post("/api/v1/app/result")
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(jsonTestResultRequest.write(request).getJson()))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(MockMvcResultMatchers.content().string(StringUtils.EMPTY))
+        .andDo(MockMvcResultHandlers.print());
+    } catch (Exception e) {
+      Assert.fail();
+    }
   }
 
 }


### PR DESCRIPTION
I considered a refactor for the controller tests since they were full integration tests. In fact i recognized all the test classed had a full integration test. This can lead to mixed up application context loading (more specifically the state). For furthere reference please see the following link, it is well written to understand the difference.

- https://thepracticaldeveloper.com/2017/07/30/guide-spring-boot-controller-tests/


So i started to refactor to a tailored controller test even without the `WebMvcTest`, but then i realized we need the annotation, because the annotation `@Valid` was not beeing considered in the context. So this is the necessary context loading for the controller test.

For the first commit please see

- https://stackoverflow.com/a/51558289/11770752

The `@EnableJpaAudit` in `TestResultApplication` was blocking the tests, since the JPA context should have been loaded. But the goal was to reduce context beeing loaded, so therefore moved to a configuration class as it is the proper way of handling configurations anyway.

---

For further Unit Tests please consider loading only the necessary context, since with increasing test cases (and all are fully loaded into spring test context) there is likely to be a mixup where we need to use `@DirtiesContext`. For example the service tests do not need a full spring context either to be tested. `JUnit` with `Mockito` and `SpringJUnit4ClassRunner` is perfectly fine. 
If we piece our Unit Tests like small gearwheels depended on layers we get a really good net of testing to fall back and changes of code lead to precice changes in our tests.

In Addition it is considerable to do extra integration testing with a full context to simulate through all the layers.

---
Edit: I know the mockMvc could have been extracted and used multiple times in the test methods. I did not do it, since for testing purpose it is much clearer to have the necessary code inside the test method.