### PR TITLE
refactor/mappings

### DIFF
--- a/src/main/java/app/coronawarn/testresult/TestResultController.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultController.java
@@ -21,6 +21,8 @@
 
 package app.coronawarn.testresult;
 
+import app.coronawarn.testresult.mapper.model.TestResultRequestToTestResult;
+import app.coronawarn.testresult.mapper.model.TestResultToTestResultResponse;
 import app.coronawarn.testresult.model.TestResult;
 import app.coronawarn.testresult.model.TestResultRequest;
 import app.coronawarn.testresult.model.TestResultResponse;
@@ -44,6 +46,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestResultController {
 
   private final TestResultService testResultService;
+  private final TestResultRequestToTestResult toTestResultMapper;
+  private final TestResultToTestResultResponse toTestResultResponseMapper;
 
   /**
    * Get the test result response from a request containing the id.
@@ -62,9 +66,10 @@ public class TestResultController {
   public ResponseEntity<TestResultResponse> result(
     @RequestBody @Valid TestResultRequest request
   ) {
-    TestResult result = testResultService.getOrInsert(request.getId());
-    return ResponseEntity.ok(new TestResultResponse()
-      .setTestResult(result.getResult() == null ? 0 : result.getResult()));
+    TestResult toSearch = toTestResultMapper.map(request);
+    TestResult result = testResultService.insertAndUpdate(toSearch);
+    TestResultResponse response = toTestResultResponseMapper.map(result);
+    return ResponseEntity.ok(response);
   }
 
   /**
@@ -84,7 +89,7 @@ public class TestResultController {
   public ResponseEntity<?> results(
     @RequestBody @NotEmpty List<@Valid TestResult> request
   ) {
-    request.forEach(testResultService::insertOrUpdate);
+    request.forEach(testResultService::getOrInsert);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/app/coronawarn/testresult/mapper/Mapper.java
+++ b/src/main/java/app/coronawarn/testresult/mapper/Mapper.java
@@ -1,0 +1,6 @@
+package app.coronawarn.testresult.mapper;
+
+public interface Mapper<S, D> {
+
+  D map(S source);
+}

--- a/src/main/java/app/coronawarn/testresult/mapper/entity/TestResultEntityToTestResult.java
+++ b/src/main/java/app/coronawarn/testresult/mapper/entity/TestResultEntityToTestResult.java
@@ -1,0 +1,19 @@
+package app.coronawarn.testresult.mapper.entity;
+
+import app.coronawarn.testresult.entity.TestResultEntity;
+import app.coronawarn.testresult.mapper.Mapper;
+import app.coronawarn.testresult.model.TestResult;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestResultEntityToTestResult implements Mapper<TestResultEntity, TestResult> {
+
+  @Override
+  public TestResult map(TestResultEntity source) {
+    TestResult destination = new TestResult();
+    
+    return destination
+      .setId(source.getResultId())
+      .setResult(source.getResult());
+  }
+}

--- a/src/main/java/app/coronawarn/testresult/mapper/entity/TestResultToTestResultEntity.java
+++ b/src/main/java/app/coronawarn/testresult/mapper/entity/TestResultToTestResultEntity.java
@@ -1,0 +1,21 @@
+package app.coronawarn.testresult.mapper.entity;
+
+import app.coronawarn.testresult.entity.TestResultEntity;
+import app.coronawarn.testresult.mapper.Mapper;
+import app.coronawarn.testresult.model.TestResult;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestResultToTestResultEntity implements Mapper<TestResult, TestResultEntity> {
+
+  @Override
+  public TestResultEntity map(TestResult source) {
+    TestResultEntity destination = new TestResultEntity();
+    
+    return destination
+      .setResult(source.getResult())
+      .setResultId(source.getId())
+      .setResultDate(LocalDateTime.now());
+  }
+}

--- a/src/main/java/app/coronawarn/testresult/mapper/entity/TestResultToTestResultEntity.java
+++ b/src/main/java/app/coronawarn/testresult/mapper/entity/TestResultToTestResultEntity.java
@@ -12,10 +12,28 @@ public class TestResultToTestResultEntity implements Mapper<TestResult, TestResu
   @Override
   public TestResultEntity map(TestResult source) {
     TestResultEntity destination = new TestResultEntity();
-    
+
     return destination
       .setResult(source.getResult())
       .setResultId(source.getId())
       .setResultDate(LocalDateTime.now());
+  }
+
+  /**
+   * Mapping to {@link TestResultEntity} with a specific test result value to be inserted into
+   * database.
+   *
+   * @param source          {@link TestResult} from a request incoming
+   * @param testResultValue refer to {@link TestResultEntity.Result} - insert this as {@code
+   *                        ordinal()}
+   * @return Entity to be save into database
+   */
+  public TestResultEntity mapWithResultValue(TestResult source, int testResultValue) {
+    TestResultEntity destination = new TestResultEntity();
+
+    return
+      destination.setResult(testResultValue)
+        .setResultId(source.getId())
+        .setResultDate(LocalDateTime.now());
   }
 }

--- a/src/main/java/app/coronawarn/testresult/mapper/model/TestResultRequestToTestResult.java
+++ b/src/main/java/app/coronawarn/testresult/mapper/model/TestResultRequestToTestResult.java
@@ -1,0 +1,22 @@
+package app.coronawarn.testresult.mapper.model;
+
+import app.coronawarn.testresult.mapper.Mapper;
+import app.coronawarn.testresult.model.TestResult;
+import app.coronawarn.testresult.model.TestResultRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestResultRequestToTestResult implements Mapper<TestResultRequest, TestResult> {
+
+  private static final Integer NO_TEST_RESULT_EVALUATED = 0;
+
+  @Override
+  public TestResult map(TestResultRequest source) {
+    TestResult destination = new TestResult();
+
+    return
+      destination
+        .setId(source.getId())
+        .setResult(NO_TEST_RESULT_EVALUATED);
+  }
+}

--- a/src/main/java/app/coronawarn/testresult/mapper/model/TestResultToTestResultResponse.java
+++ b/src/main/java/app/coronawarn/testresult/mapper/model/TestResultToTestResultResponse.java
@@ -1,0 +1,20 @@
+package app.coronawarn.testresult.mapper.model;
+
+import app.coronawarn.testresult.mapper.Mapper;
+import app.coronawarn.testresult.model.TestResult;
+import app.coronawarn.testresult.model.TestResultResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestResultToTestResultResponse implements Mapper<TestResult, TestResultResponse> {
+
+  @Override
+  public TestResultResponse map(TestResult source) {
+    TestResultResponse destination = new TestResultResponse();
+    Integer testResultValue = source.getResult();
+    destination.setTestResult(testResultValue);
+
+    return destination;
+  }
+
+}

--- a/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
@@ -59,11 +59,11 @@ public class TestResultServiceTest {
       .setId(id)
       .setResult(result);
     // insert
-    testResult = testResultService.insertOrUpdate(testResult);
+    testResult = testResultService.insertAndUpdate(testResult);
     Assert.assertNotNull(testResult);
     Assert.assertEquals(result, testResult.getResult());
     // get
-    testResult = testResultService.getOrInsert(id);
+    testResult = testResultService.getOrInsert(testResult);
     Assert.assertNotNull(testResult);
     Assert.assertEquals(result, testResult.getResult());
   }

--- a/src/test/java/app/coronawarn/testresult/mapper/entity/TestResultEntityToTestResultTest.java
+++ b/src/test/java/app/coronawarn/testresult/mapper/entity/TestResultEntityToTestResultTest.java
@@ -1,0 +1,86 @@
+package app.coronawarn.testresult.mapper.entity;
+
+import app.coronawarn.testresult.entity.TestResultEntity;
+import app.coronawarn.testresult.model.TestResult;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestResultEntityToTestResultTest {
+
+  private Validator validator;
+  private TestResultEntityToTestResult mapper;
+
+  @Before
+  public void setup() {
+    mapper = new TestResultEntityToTestResult();
+
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  public void map_validTestResultEntity_returnsValidTestResult() {
+    String validId = "a".repeat(64);
+    Integer negativeTestResult = 1;
+    TestResultEntity source =
+      new TestResultEntity()
+        .setResultId(validId)
+        .setResult(negativeTestResult);
+    TestResult expected = new TestResult().setId(validId).setResult(negativeTestResult);
+
+    checkForValidationErrors(expected, 0);
+
+    TestResult actual = mapper.map(source);
+    checkForValidationErrors(actual, 0);
+    Assert.assertTrue(EqualsBuilder.reflectionEquals(expected, actual));
+  }
+
+  @Test
+  public void map_invalidTestResultEntity_throwsContraintViolationError() {
+    String validId = "a".repeat(66);
+    Integer invalidTestResultValue = 0;
+    TestResultEntity source =
+      new TestResultEntity()
+        .setResultId(validId)
+        .setResult(invalidTestResultValue);
+    TestResult expected = new TestResult().setId(validId).setResult(invalidTestResultValue);
+
+    checkForValidationErrors(expected, 2);
+
+    TestResult actual = mapper.map(source);
+    checkForValidationErrors(actual, 2);
+    Assert.assertTrue(EqualsBuilder.reflectionEquals(expected, actual));
+  }
+
+  @Test
+  public void map_emptyTestResultEntity_throwsContraintViolationError() {
+    TestResultEntity source = new TestResultEntity();
+    TestResult expected = new TestResult();
+
+    checkForValidationErrors(expected, 2);
+
+    TestResult actual = mapper.map(source);
+    checkForValidationErrors(actual, 2);
+    Assert.assertTrue(EqualsBuilder.reflectionEquals(expected, actual));
+  }
+
+  @Test
+  public void map_TestResultEntityNotInitilized_resultingInNullPointerException() {
+    TestResultEntity source = null;
+
+    Assert.assertThrows(NullPointerException.class, () -> mapper.map(source));
+  }
+
+
+  //### H E L P E R ###
+  private <E> void checkForValidationErrors(E objectToValidate, int expectedErrors) {
+
+    Set<ConstraintViolation<E>> violations = validator.validate(objectToValidate);
+    Assert.assertEquals(expectedErrors, violations.size());
+  }
+}

--- a/src/test/java/app/coronawarn/testresult/mapper/entity/TestResultEntityToTestResultTest.java
+++ b/src/test/java/app/coronawarn/testresult/mapper/entity/TestResultEntityToTestResultTest.java
@@ -62,10 +62,10 @@ public class TestResultEntityToTestResultTest {
     TestResultEntity source = new TestResultEntity();
     TestResult expected = new TestResult();
 
-    checkForValidationErrors(expected, 2);
+    checkForValidationErrors(expected, 1);
 
     TestResult actual = mapper.map(source);
-    checkForValidationErrors(actual, 2);
+    checkForValidationErrors(actual, 1);
     Assert.assertTrue(EqualsBuilder.reflectionEquals(expected, actual));
   }
 

--- a/src/test/java/app/coronawarn/testresult/mapper/entity/TestResultToTestResultEntityTest.java
+++ b/src/test/java/app/coronawarn/testresult/mapper/entity/TestResultToTestResultEntityTest.java
@@ -1,0 +1,40 @@
+package app.coronawarn.testresult.mapper.entity;
+
+import app.coronawarn.testresult.entity.TestResultEntity;
+import app.coronawarn.testresult.model.TestResult;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestResultToTestResultEntityTest {
+
+  private TestResultToTestResultEntity mapper;
+
+  @Before
+  public void setup() {
+    mapper = new TestResultToTestResultEntity();
+  }
+
+  @Test
+  public void map_validTestResultEntity_returnsValidTestResult() {
+    String validId = "a".repeat(64);
+    Integer negativeTestResult = 1;
+    TestResult source = new TestResult().setId(validId).setResult(negativeTestResult);
+    TestResultEntity expected =
+      new TestResultEntity()
+        .setResultId(validId)
+        .setResult(negativeTestResult);
+
+    TestResultEntity actual = mapper.map(source);
+    Assert.assertTrue(EqualsBuilder.reflectionEquals(expected, actual, "resultDate"));
+  }
+
+  @Test
+  public void map_TestResultNotInitilized_resultingInNullPointerException() {
+    TestResult source = null;
+
+    Assert.assertThrows(NullPointerException.class, () -> mapper.map(source));
+  }
+
+}

--- a/src/test/java/app/coronawarn/testresult/mapper/model/TestResultRequestToTestResultTest.java
+++ b/src/test/java/app/coronawarn/testresult/mapper/model/TestResultRequestToTestResultTest.java
@@ -1,0 +1,67 @@
+package app.coronawarn.testresult.mapper.model;
+
+import app.coronawarn.testresult.model.TestResult;
+import app.coronawarn.testresult.model.TestResultRequest;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestResultRequestToTestResultTest {
+
+  private Validator validator;
+  private TestResultRequestToTestResult mapper;
+
+  @Before
+  public void setup() {
+    mapper = new TestResultRequestToTestResult();
+
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  public void map_validTestResultRequestWithValue_returnsValidTestResult() {
+    String validId = "a".repeat(64);
+    Integer noTestResultEvaluated = 0;
+    TestResultRequest source = new TestResultRequest().setId(validId);
+    TestResult expected = new TestResult().setId(validId).setResult(noTestResultEvaluated);
+
+    checkForValidationErrors(source, 0);
+    // change to 0 expected errors after PR#56 was merged
+    checkForValidationErrors(expected, 1);
+
+    TestResult actual = mapper.map(source);
+    // change to 0 expected errors after PR#56 was merged
+    checkForValidationErrors(actual, 1);
+    Assert.assertTrue(EqualsBuilder.reflectionEquals(expected, actual));
+  }
+
+  @Test
+  public void map_TestResultNotInitilized_resultingInNullPointerException() {
+    TestResultRequest source = null;
+
+    Assert.assertThrows(NullPointerException.class, () -> mapper.map(source));
+  }
+
+  @Test
+  public void map_invalidTestResulRequest_throwsValidationErrors() {
+    TestResultRequest source = new TestResultRequest();
+
+    TestResult actual = mapper.map(source);
+
+    checkForValidationErrors(actual, 2);
+  }
+
+  //### H E L P E R ###
+  private <E> void checkForValidationErrors(E objectToValidate, int expectedErrors) {
+
+    Set<ConstraintViolation<E>> violations = validator.validate(objectToValidate);
+    violations.forEach(System.out::println);
+    Assert.assertEquals(expectedErrors, violations.size());
+  }
+
+}

--- a/src/test/java/app/coronawarn/testresult/mapper/model/TestResultToTestResultResponseTest.java
+++ b/src/test/java/app/coronawarn/testresult/mapper/model/TestResultToTestResultResponseTest.java
@@ -1,0 +1,68 @@
+package app.coronawarn.testresult.mapper.model;
+
+import app.coronawarn.testresult.model.TestResult;
+import app.coronawarn.testresult.model.TestResultResponse;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestResultToTestResultResponseTest {
+
+  private Validator validator;
+  private TestResultToTestResultResponse mapper;
+
+  @Before
+  public void setup() {
+    mapper = new TestResultToTestResultResponse();
+
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  public void map_validTestResultWithValue_returnsValidTestResultResponse() {
+    String validId = "a".repeat(64);
+    Integer negativeTestResult = 1;
+    TestResult source = new TestResult().setId(validId).setResult(negativeTestResult);
+    TestResultResponse expected = new TestResultResponse().setTestResult(negativeTestResult);
+
+    checkForValidationErrors(source, 0);
+    checkForValidationErrors(expected, 0);
+
+    TestResultResponse actual = mapper.map(source);
+    checkForValidationErrors(actual, 0);
+    Assert.assertTrue(EqualsBuilder.reflectionEquals(expected, actual));
+  }
+
+  @Test
+  public void map_TestResultNotInitilized_resultingInNullPointerException() {
+    TestResult source = null;
+
+    Assert.assertThrows(NullPointerException.class, () -> mapper.map(source));
+  }
+
+  @Test
+  public void map_validTestResultWithoutValue_returnsValidTestResultResponseWithoutValue() {
+    String validId = "a".repeat(64);
+    Integer noTestResult = null;
+    TestResult source = new TestResult().setId(validId).setResult(noTestResult);
+    TestResultResponse expected = new TestResultResponse().setTestResult(noTestResult);
+
+    TestResultResponse actual = mapper.map(source);
+
+    checkForValidationErrors(actual, 1);
+    Assert.assertTrue(EqualsBuilder.reflectionEquals(expected, actual));
+  }
+
+  //### H E L P E R ###
+  private <E> void checkForValidationErrors(E objectToValidate, int expectedErrors) {
+
+    Set<ConstraintViolation<E>> violations = validator.validate(objectToValidate);
+    Assert.assertEquals(expectedErrors, violations.size());
+  }
+
+}


### PR DESCRIPTION
With this PR i want to indroduce mappings between our Entity and Model (Data Transfer Objects) and vice versa. Additionally some mapping between the models.

**Benefit** is improved encapsulation and readability. If there are more entities and models comings it is easy to get going and create them (Open Closed Principle).

[insertAndUpdate](https://github.com/corona-warn-app/cwa-testresult-server/pull/57/files#diff-d23f50e7a89059497c9bca9396fe18dcR49) - renamed since it's more precise what is happening inside this method. There is **always** an updating happening. I'll create an issue in this regard, since database access is _expensive_.

<s>Please have a look at #56 - The order of merging is relevant. Changes have to be made in mappings, since i expect #56 is going to be merged first. Value `0` is going to be valid in `TestResult`. [Important notes](#diff-083bfc173a57c427c81478e984248e8fR34)<s>