### PR TITLE
feat: database improve and mapping

### DIFF
--- a/src/main/java/app/coronawarn/testresult/TestResultController.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultController.java
@@ -62,7 +62,7 @@ public class TestResultController {
   public ResponseEntity<TestResultResponse> result(
     @RequestBody @Valid TestResultRequest request
   ) {
-    TestResult result = testResultService.getOrInsert(request.getId());
+    TestResult result = testResultService.getOrCreate(request.getId());
     return ResponseEntity.ok(new TestResultResponse()
       .setTestResult(result.getResult() == null ? 0 : result.getResult()));
   }
@@ -84,7 +84,7 @@ public class TestResultController {
   public ResponseEntity<?> results(
     @RequestBody @NotEmpty List<@Valid TestResult> request
   ) {
-    request.forEach(testResultService::insertOrUpdate);
+    request.forEach(testResultService::createOrUpdate);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/app/coronawarn/testresult/TestResultService.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultService.java
@@ -38,12 +38,25 @@ public class TestResultService {
 
   private final TestResultRepository testResultRepository;
 
+  /**
+   * Map the entity of a test result to a test result model.
+   *
+   * @param entity the test result entity to map
+   * @return the mapped model from entity
+   */
   public TestResult toModel(TestResultEntity entity) {
     return new TestResult()
       .setId(entity.getResultId())
       .setResult(entity.getResult());
   }
 
+  /**
+   * Map the model of a test result to a test result entity.
+   * This will also set current date time as value for result date.
+   *
+   * @param model the test result model to map
+   * @return the mapped entity from model
+   */
   public TestResultEntity toEntity(TestResult model) {
     return new TestResultEntity()
       .setResult(model.getResult())

--- a/src/main/java/app/coronawarn/testresult/entity/TestResultEntity.java
+++ b/src/main/java/app/coronawarn/testresult/entity/TestResultEntity.java
@@ -48,33 +48,23 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "test_result")
 public class TestResultEntity {
 
-  public enum Result {
-    PENDING, NEGATIVE, POSITIVE, INVALID, REDEEMED
-  }
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
   private Long id;
-
   @CreatedDate
   @Column(name = "created_at")
   private LocalDateTime createdAt;
-
   @LastModifiedDate
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
-
   @Version
   @Column(name = "version")
   private Long version;
-
   @Column(name = "result")
   private Integer result;
-
   @Column(name = "result_id")
   private String resultId;
-
   @Column(name = "result_date")
   private LocalDateTime resultDate;
 
@@ -91,5 +81,9 @@ public class TestResultEntity {
   public TestResultEntity setResultDate(LocalDateTime resultDate) {
     this.resultDate = resultDate;
     return this;
+  }
+
+  public enum Result {
+    PENDING, NEGATIVE, POSITIVE, INVALID, REDEEMED
   }
 }

--- a/src/main/java/app/coronawarn/testresult/model/TestResult.java
+++ b/src/main/java/app/coronawarn/testresult/model/TestResult.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
@@ -21,16 +21,15 @@
 
 package app.coronawarn.testresult;
 
-import app.coronawarn.testresult.exception.TestResultException;
+import app.coronawarn.testresult.entity.TestResultEntity;
 import app.coronawarn.testresult.model.TestResult;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -45,41 +44,89 @@ public class TestResultServiceTest {
   @Autowired
   private TestResultRepository testResultRepository;
 
-  @Before
+  @BeforeEach
   public void before() {
     testResultRepository.deleteAll();
   }
 
   @Test
-  public void insert() {
+  public void toEntityAndToModel() {
     // data
     String id = "a".repeat(64);
     Integer result = 1;
-    TestResult testResult = new TestResult()
-      .setId(id)
-      .setResult(result);
-    // insert
-    testResult = testResultService.insertOrUpdate(testResult);
-    Assert.assertNotNull(testResult);
-    Assert.assertEquals(result, testResult.getResult());
-    // get
-    testResult = testResultService.getOrInsert(id);
-    Assert.assertNotNull(testResult);
-    Assert.assertEquals(result, testResult.getResult());
+    // toEntity
+    TestResult model = new TestResult()
+      .setId("a".repeat(64))
+      .setResult(1);
+    TestResultEntity entity = testResultService.toEntity(model);
+    Assert.assertNotNull(entity);
+    Assert.assertEquals(id, entity.getResultId());
+    Assert.assertEquals(result, entity.getResult());
+    // toModel
+    model = testResultService.toModel(entity);
+    Assert.assertNotNull(model);
+    Assert.assertEquals(id, model.getId());
+    Assert.assertEquals(result, model.getResult());
   }
 
   @Test
-  public void getNotFound() {
+  public void insertOrUpdate() {
     // data
-    String id = "b".repeat(64);
+    String id = "a".repeat(64);
+    Integer result = 1;
+    TestResult create = new TestResult()
+      .setId(id)
+      .setResult(result);
+    // create
+    create = testResultService.createOrUpdate(create);
+    Assert.assertNotNull(create);
+    Assert.assertEquals(result, create.getResult());
     // get
-    try {
-      //should always return pending test result
-      //testResultService.get(id);
-      //Assert.fail();
-    } catch (TestResultException e) {
-      Assert.assertEquals(HttpStatus.NOT_FOUND, e.getStatus());
-    }
+    TestResult get = testResultService.getOrCreate(id);
+    Assert.assertNotNull(get);
+    Assert.assertEquals(result, get.getResult());
+  }
+
+  @Test
+  public void insertAndUpdate() {
+    // data
+    String id = "a".repeat(64);
+    Integer resultCreate = 1;
+    Integer resultUpdate = 2;
+    TestResult create = new TestResult()
+      .setId(id)
+      .setResult(resultCreate);
+    // create
+    create = testResultService.createOrUpdate(create);
+    Assert.assertNotNull(create);
+    Assert.assertEquals(resultCreate, create.getResult());
+    // get
+    TestResult get = testResultService.getOrCreate(id);
+    Assert.assertNotNull(get);
+    Assert.assertEquals(resultCreate, get.getResult());
+    // update
+    TestResult update = new TestResult()
+      .setId(id)
+      .setResult(resultUpdate);
+    update = testResultService.createOrUpdate(update);
+    Assert.assertNotNull(update);
+    Assert.assertEquals(resultUpdate, update.getResult());
+    // get
+    get = testResultService.getOrCreate(id);
+    Assert.assertNotNull(get);
+    Assert.assertEquals(resultUpdate, get.getResult());
+  }
+
+  @Test
+  public void getOrCreate() {
+    // data
+    String id = "a".repeat(64);
+    Integer result = 0;
+    // get
+    // get
+    TestResult get = testResultService.getOrCreate(id);
+    Assert.assertNotNull(get);
+    Assert.assertEquals(result, get.getResult());
   }
 
 }

--- a/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
@@ -54,15 +54,15 @@ public class TestResultServiceTest {
     // data
     String id = "a".repeat(64);
     Integer result = 1;
-    // toEntity
+    // to entity
     TestResult model = new TestResult()
-      .setId("a".repeat(64))
-      .setResult(1);
+      .setId(id)
+      .setResult(result);
     TestResultEntity entity = testResultService.toEntity(model);
     Assert.assertNotNull(entity);
     Assert.assertEquals(id, entity.getResultId());
     Assert.assertEquals(result, entity.getResult());
-    // toModel
+    // to model
     model = testResultService.toModel(entity);
     Assert.assertNotNull(model);
     Assert.assertEquals(id, model.getId());

--- a/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
@@ -123,7 +123,6 @@ public class TestResultServiceTest {
     String id = "a".repeat(64);
     Integer result = 0;
     // get
-    // get
     TestResult get = testResultService.getOrCreate(id);
     Assert.assertNotNull(get);
     Assert.assertEquals(result, get.getResult());

--- a/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
@@ -24,8 +24,8 @@ package app.coronawarn.testresult;
 import app.coronawarn.testresult.entity.TestResultEntity;
 import app.coronawarn.testresult.model.TestResult;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -44,7 +44,7 @@ public class TestResultServiceTest {
   @Autowired
   private TestResultRepository testResultRepository;
 
-  @BeforeEach
+  @Before
   public void before() {
     testResultRepository.deleteAll();
   }


### PR DESCRIPTION
This PR improves database entity creation to not always execute create and update at same time.
Also mapping (in service) was excluded in separate methods.
