### PR TITLE
Make model classes immutable

### DIFF
--- a/src/main/java/app/coronawarn/testresult/TestResultController.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultController.java
@@ -64,8 +64,9 @@ public class TestResultController {
   ) {
     log.info("Received test result request from app.");
     TestResult result = testResultService.getOrCreate(request.getId());
-    return ResponseEntity.ok(new TestResultResponse()
-      .setTestResult(result.getResult() == null ? 0 : result.getResult()));
+    return ResponseEntity.ok(TestResultResponse.builder()
+      .testResult(result.getResult() == null ? 0 : result.getResult())
+      .build());
   }
 
   /**

--- a/src/main/java/app/coronawarn/testresult/TestResultService.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultService.java
@@ -45,9 +45,10 @@ public class TestResultService {
    * @return the mapped model from entity
    */
   public TestResult toModel(TestResultEntity entity) {
-    return new TestResult()
-      .setId(entity.getResultId())
-      .setResult(entity.getResult());
+    return TestResult.builder()
+      .id(entity.getResultId())
+      .result(entity.getResult())
+      .build();
   }
 
   /**

--- a/src/main/java/app/coronawarn/testresult/model/TestResult.java
+++ b/src/main/java/app/coronawarn/testresult/model/TestResult.java
@@ -21,14 +21,15 @@
 
 package app.coronawarn.testresult.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Value;
 
 /**
  * Model of the test result.
@@ -36,9 +37,8 @@ import lombok.ToString;
 @Schema(
   description = "The test result model."
 )
-@Getter
-@ToString
-@EqualsAndHashCode
+@Value
+@Builder
 public class TestResult {
 
   /**
@@ -58,13 +58,10 @@ public class TestResult {
   @Max(3)
   private Integer result;
 
-  public TestResult setId(String id) {
-    this.id = id;
-    return this;
-  }
 
-  public TestResult setResult(Integer result) {
+  @JsonCreator
+  public TestResult(@JsonProperty("id") String id, @JsonProperty("result") Integer result) {
+    this.id = id;
     this.result = result;
-    return this;
   }
 }

--- a/src/main/java/app/coronawarn/testresult/model/TestResultRequest.java
+++ b/src/main/java/app/coronawarn/testresult/model/TestResultRequest.java
@@ -21,12 +21,13 @@
 
 package app.coronawarn.testresult.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Value;
 
 /**
  * Request model of the test result.
@@ -34,9 +35,8 @@ import lombok.ToString;
 @Schema(
   description = "The test result request model."
 )
-@Getter
-@ToString
-@EqualsAndHashCode
+@Value
+@Builder
 public class TestResultRequest {
 
   /**
@@ -44,10 +44,10 @@ public class TestResultRequest {
    */
   @NotBlank
   @Pattern(regexp = "^([A-Fa-f0-9]{2}){32}$")
-  private String id;
+  String id;
 
-  public TestResultRequest setId(String id) {
+  @JsonCreator
+  public TestResultRequest(@JsonProperty("id") String id) {
     this.id = id;
-    return this;
   }
 }

--- a/src/main/java/app/coronawarn/testresult/model/TestResultResponse.java
+++ b/src/main/java/app/coronawarn/testresult/model/TestResultResponse.java
@@ -25,9 +25,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.Builder;
+import lombok.Value;
 
 /**
  * Response model of the test result.
@@ -35,9 +34,8 @@ import lombok.ToString;
 @Schema(
   description = "The test result response model."
 )
-@Getter
-@ToString
-@EqualsAndHashCode
+@Value
+@Builder
 public class TestResultResponse {
 
   /**
@@ -51,10 +49,5 @@ public class TestResultResponse {
   @NotNull
   @Min(0)
   @Max(4)
-  private Integer testResult;
-
-  public TestResultResponse setTestResult(Integer testResult) {
-    this.testResult = testResult;
-    return this;
-  }
+  Integer testResult;
 }

--- a/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
@@ -65,7 +65,7 @@ public class TestResultControllerTest {
     Integer result = 0;
     // create
     List<TestResult> invalid = Collections.singletonList(
-      new TestResult().setId("").setResult(0)
+      TestResult.builder().id("").result(0).build()
     );
     mockMvc.perform(MockMvcRequestBuilders
       .post("/api/v1/lab/results")
@@ -83,7 +83,7 @@ public class TestResultControllerTest {
     Integer result = 1;
     // create
     List<TestResult> valid = Collections.singletonList(
-      new TestResult().setId(id).setResult(result)
+      TestResult.builder().id(id).result(result).build()
     );
     mockMvc.perform(MockMvcRequestBuilders
       .post("/api/v1/lab/results")
@@ -101,7 +101,7 @@ public class TestResultControllerTest {
     Integer result = 1;
     // create
     List<TestResult> valid = Collections.singletonList(
-      new TestResult().setId(id).setResult(result)
+      TestResult.builder().id(id).result(result).build()
     );
     mockMvc.perform(MockMvcRequestBuilders
       .post("/api/v1/lab/results")
@@ -111,8 +111,9 @@ public class TestResultControllerTest {
       .andDo(MockMvcResultHandlers.print())
       .andExpect(MockMvcResultMatchers.status().isNoContent());
     // get
-    TestResultRequest request = new TestResultRequest()
-      .setId(id);
+    TestResultRequest request = TestResultRequest.builder()
+      .id(id)
+      .build();
     mockMvc.perform(MockMvcRequestBuilders
       .post("/api/v1/app/result")
       .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -128,7 +129,7 @@ public class TestResultControllerTest {
     String id = "b".repeat(64);
     // create
     List<TestResult> valid = Collections.singletonList(
-      new TestResult().setId(id)
+      TestResult.builder().id(id).build()
     );
     mockMvc.perform(MockMvcRequestBuilders
       .post("/api/v1/lab/results")
@@ -138,8 +139,9 @@ public class TestResultControllerTest {
       .andDo(MockMvcResultHandlers.print())
       .andExpect(MockMvcResultMatchers.status().isNoContent());
     // get
-    TestResultRequest request = new TestResultRequest()
-      .setId(id);
+    TestResultRequest request = TestResultRequest.builder()
+      .id(id)
+      .build();
     mockMvc.perform(MockMvcRequestBuilders
       .post("/api/v1/app/result")
       .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -156,11 +158,12 @@ public class TestResultControllerTest {
     Integer result = 1;
     // create
     List<TestResult> valid = Collections.singletonList(
-      new TestResult().setId(id).setResult(result)
+      TestResult.builder().id(id).build()
     );
     // get
-    TestResultRequest request = new TestResultRequest()
-      .setId(id);
+    TestResultRequest request = TestResultRequest.builder()
+      .id(id)
+      .build();
     mockMvc.perform(MockMvcRequestBuilders
       .post("/api/v1/app/result")
       .accept(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
@@ -55,9 +55,10 @@ public class TestResultServiceTest {
     String id = "a".repeat(64);
     Integer result = 1;
     // to entity
-    TestResult model = new TestResult()
-      .setId(id)
-      .setResult(result);
+    TestResult model = TestResult.builder()
+      .id(id)
+      .result(result)
+      .build();
     TestResultEntity entity = testResultService.toEntity(model);
     Assert.assertNotNull(entity);
     Assert.assertEquals(id, entity.getResultId());
@@ -74,9 +75,10 @@ public class TestResultServiceTest {
     // data
     String id = "a".repeat(64);
     Integer result = 1;
-    TestResult create = new TestResult()
-      .setId(id)
-      .setResult(result);
+    TestResult create = TestResult.builder()
+      .id(id)
+      .result(result)
+      .build();
     // create
     create = testResultService.createOrUpdate(create);
     Assert.assertNotNull(create);
@@ -93,9 +95,10 @@ public class TestResultServiceTest {
     String id = "a".repeat(64);
     Integer resultCreate = 1;
     Integer resultUpdate = 2;
-    TestResult create = new TestResult()
-      .setId(id)
-      .setResult(resultCreate);
+    TestResult create = TestResult.builder()
+      .id(id)
+      .result(resultCreate)
+      .build();
     // create
     create = testResultService.createOrUpdate(create);
     Assert.assertNotNull(create);
@@ -105,9 +108,10 @@ public class TestResultServiceTest {
     Assert.assertNotNull(get);
     Assert.assertEquals(resultCreate, get.getResult());
     // update
-    TestResult update = new TestResult()
-      .setId(id)
-      .setResult(resultUpdate);
+    TestResult update = TestResult.builder()
+      .id(id)
+      .result(resultUpdate)
+      .build();
     update = testResultService.createOrUpdate(update);
     Assert.assertNotNull(update);
     Assert.assertEquals(resultUpdate, update.getResult());

--- a/src/test/java/app/coronawarn/testresult/model/TestResultRequestTest.java
+++ b/src/test/java/app/coronawarn/testresult/model/TestResultRequestTest.java
@@ -1,0 +1,20 @@
+package app.coronawarn.testresult.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestResultRequestTest {
+
+  @Test
+  public void canBeDeSerializedFromJson() throws Exception {
+    String json = "{\"id\":\"c8aefb946227866a1172b76c03103acf0ced8a356098bfabd0b4e10665331654\"}";
+    var testResultRequest = new ObjectMapper().readValue(json, TestResultRequest.class);
+
+    Assert.assertEquals(
+        TestResultRequest.builder()
+            .id("c8aefb946227866a1172b76c03103acf0ced8a356098bfabd0b4e10665331654")
+            .build(),
+        testResultRequest);
+  }
+}

--- a/src/test/java/app/coronawarn/testresult/model/TestResultResponseTest.java
+++ b/src/test/java/app/coronawarn/testresult/model/TestResultResponseTest.java
@@ -1,0 +1,17 @@
+package app.coronawarn.testresult.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public class TestResultResponseTest {
+
+  @Test
+  public void canBeSerializedToJson() throws Exception {
+    var testResultResponse = TestResultResponse.builder().testResult(1).build();
+
+    String json = new ObjectMapper().writeValueAsString(testResultResponse);
+
+    JSONAssert.assertEquals("{\"testResult\":1}", json, true);
+  }
+}

--- a/src/test/java/app/coronawarn/testresult/model/TestResultTest.java
+++ b/src/test/java/app/coronawarn/testresult/model/TestResultTest.java
@@ -1,0 +1,23 @@
+package app.coronawarn.testresult.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestResultTest {
+
+  @Test
+  public void canBeDeSerializedFromJson() throws Exception {
+    String json =
+        "{\"id\":\"c8aefb946227866a1172b76c03103acf0ced8a356098bfabd0b4e10665331654\",\"result\":1}";
+
+    var testResult = new ObjectMapper().readValue(json, TestResult.class);
+
+    Assert.assertEquals(
+        TestResult.builder()
+            .id("c8aefb946227866a1172b76c03103acf0ced8a356098bfabd0b4e10665331654")
+            .result(1)
+            .build(),
+        testResult);
+  }
+}


### PR DESCRIPTION
Insted of using hand-crafted `set` methods returning the same mutable object, consider using a combination of Lombok's `@Value` and `@Builder`. `@Value` will generate an immutable
class and `@Builder` will allow to construct it in a fluent fashion.

Immutability is an important treat of domain objects, since they can be constructed once a consistent state and be safely shared.

See:
* Item 15: Minimize mutability" Effective Java, Second Edition
* [AutoValue: what, why and how?](https://docs.google.com/presentation/d/14u_h-lMn7f1rXE1nDiLX0azS3IkgjGl5uxp5jGJ75RE/edit#slide=id.g2a5e9c4a8_00)