### PR TITLE
feat: deny redeemed result updates

### DIFF
--- a/src/main/java/app/coronawarn/testresult/TestResultService.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultService.java
@@ -77,6 +77,10 @@ public class TestResultService {
         return testResultRepository.save(toEntity(result));
       });
       if (optional.isPresent()) {
+        if (TestResultEntity.Result.REDEEMED.ordinal() == entity.getResult()) {
+          log.info("Updating test result is not possible because result is already redeemed.");
+          return toModel(entity);
+        }
         log.info("Updating test result in database.");
         entity.setResult(result.getResult())
           .setResultDate(LocalDateTime.now());

--- a/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
@@ -128,4 +128,29 @@ public class TestResultServiceTest {
     Assert.assertEquals(result, get.getResult());
   }
 
+  @Test
+  public void createAndDenyRedeemedUpdate() {
+    // data
+    String id = "a".repeat(64);
+    Integer resultCreate = 1;
+    Integer resultUpdate = 2;
+    TestResult create = new TestResult()
+      .setId(id)
+      .setResult(resultCreate);
+    // create
+    create = testResultService.createOrUpdate(create);
+    Assert.assertNotNull(create);
+    Assert.assertEquals(resultCreate, create.getResult());
+    // redeem
+    testResultRepository.findByResultId(id)
+      .ifPresent(u -> testResultRepository.save(u
+        .setResult(TestResultEntity.Result.REDEEMED.ordinal())));
+    // update
+    TestResult update = new TestResult()
+      .setId(id)
+      .setResult(resultUpdate);
+    update = testResultService.createOrUpdate(update);
+    Assert.assertNotNull(update);
+    Assert.assertNotEquals(resultUpdate, update.getResult());
+  }
 }


### PR DESCRIPTION
We should deny updates of test results that are already in redeemed result.