### PR TITLE
feat: cleanup by created date

### DIFF
--- a/src/main/java/app/coronawarn/testresult/TestResultCleanup.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultCleanup.java
@@ -26,7 +26,7 @@ public class TestResultCleanup {
   )
   @Transactional
   public void redeem() {
-    Integer redeemed = testResultRepository.updateResultByResultDateBefore(
+    Integer redeemed = testResultRepository.updateResultByCreatedAtBefore(
       TestResultEntity.Result.REDEEMED.ordinal(),
       LocalDateTime.now().minus(Period.ofDays(testResultConfig.getCleanup().getRedeem().getDays())));
     log.info("Cleanup redeemed {} test results.", redeemed);
@@ -40,7 +40,7 @@ public class TestResultCleanup {
   )
   @Transactional
   public void delete() {
-    Integer deleted = testResultRepository.deleteByResultDateBefore(
+    Integer deleted = testResultRepository.deleteByCreatedAtBefore(
       LocalDateTime.now().minus(Period.ofDays(testResultConfig.getCleanup().getDelete().getDays())));
     log.info("Cleanup deleted {} test results.", deleted);
   }

--- a/src/main/java/app/coronawarn/testresult/TestResultRepository.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultRepository.java
@@ -33,8 +33,16 @@ public interface TestResultRepository extends JpaRepository<TestResultEntity, Lo
   Optional<TestResultEntity> findByResultId(String resultId);
 
   @Modifying
+  @Query("update TestResultEntity t set t.result = ?1 where t.result != ?1 and t.createdAt < ?2")
+  Integer updateResultByCreatedAtBefore(Integer result, LocalDateTime before);
+
+  @Modifying
   @Query("update TestResultEntity t set t.result = ?1 where t.result != ?1 and t.resultDate < ?2")
   Integer updateResultByResultDateBefore(Integer result, LocalDateTime before);
+
+  @Modifying
+  @Query("delete from TestResultEntity t where t.createdAt < ?1")
+  Integer deleteByCreatedAtBefore(LocalDateTime before);
 
   @Modifying
   @Query("delete from TestResultEntity t where t.resultDate < ?1")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,5 +50,5 @@ testresult:
       days: 21
       rate: 3600000
     delete:
-      days: 90
+      days: 60
       rate: 3600000

--- a/src/test/java/app/coronawarn/testresult/TestResultCleanupTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultCleanupTest.java
@@ -20,7 +20,7 @@ import rx.Single;
   properties = {
     "testresult.cleanup.redeem.days=21",
     "testresult.cleanup.redeem.rate=1000",
-    "testresult.cleanup.delete.days=90",
+    "testresult.cleanup.delete.days=60",
     "testresult.cleanup.delete.rate=1000"
   }
 )
@@ -43,18 +43,23 @@ public class TestResultCleanupTest {
     String resultId = "a".repeat(64);
     Integer resultRedeemed = TestResultEntity.Result.REDEEMED.ordinal();
     LocalDateTime resultDate = LocalDateTime.now().minus(Period.ofDays(21));
+    LocalDateTime createdAt = LocalDateTime.now().minus(Period.ofDays(21));
     // create
     TestResultEntity create = testResultRepository.save(new TestResultEntity()
       .setResult(1)
       .setResultId(resultId)
       .setResultDate(resultDate)
     );
+    create.setCreatedAt(createdAt);
+    testResultRepository.save(create);
     Assert.assertNotNull(create);
+    Assert.assertEquals(createdAt, create.getCreatedAt());
     Assert.assertEquals(resultId, create.getResultId());
     // find
     Optional<TestResultEntity> find = testResultRepository.findByResultId(resultId);
     Assert.assertTrue(find.isPresent());
     Assert.assertEquals(resultId, find.get().getResultId());
+    Assert.assertEquals(createdAt, find.get().getCreatedAt());
     Assert.assertEquals(resultDate, find.get().getResultDate());
     // wait
     Single.fromCallable(() -> true).delay(2, TimeUnit.SECONDS).toBlocking().value();
@@ -71,19 +76,24 @@ public class TestResultCleanupTest {
     testResultRepository.deleteAll();
     // data
     String resultId = "d".repeat(64);
-    LocalDateTime resultDate = LocalDateTime.now().minus(Period.ofDays(90));
+    LocalDateTime resultDate = LocalDateTime.now().minus(Period.ofDays(60));
+    LocalDateTime createdAt = LocalDateTime.now().minus(Period.ofDays(60));
     // create
     TestResultEntity create = testResultRepository.save(new TestResultEntity()
       .setResult(1)
       .setResultId(resultId)
       .setResultDate(resultDate)
     );
+    create.setCreatedAt(createdAt);
+    testResultRepository.save(create);
     Assert.assertNotNull(create);
+    Assert.assertEquals(createdAt, create.getCreatedAt());
     Assert.assertEquals(resultId, create.getResultId());
     // find
     Optional<TestResultEntity> find = testResultRepository.findByResultId(resultId);
     Assert.assertTrue(find.isPresent());
     Assert.assertEquals(resultId, find.get().getResultId());
+    Assert.assertEquals(createdAt, find.get().getCreatedAt());
     Assert.assertEquals(resultDate, find.get().getResultDate());
     // wait
     Single.fromCallable(() -> true).delay(2, TimeUnit.SECONDS).toBlocking().value();


### PR DESCRIPTION
We should cleanup the test results by created date.