### PR TITLE
Replace deprecated ::set-env workflow commands for security reasons

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -24,10 +24,10 @@ jobs:
       run: |
         sudo apt-get install --yes --no-install-recommends libxml-xpath-perl
         export ARTIFACT_ID=$(xpath -q -e "/project/artifactId/text()" pom.xml)
-        echo "::set-env name=ARTIFACT_ID::${ARTIFACT_ID}"
+        echo "ARTIFACT_ID=${ARTIFACT_ID}" >> $GITHUB_ENV
         export VERSION=$(xpath -q -e "/project/version/text()" pom.xml)
         export VERSION=${VERSION//-SNAPSHOT}-$(git rev-parse --short ${GITHUB_SHA})
-        echo "::set-env name=VERSION::${VERSION}"
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
     - name: mvn version
       run: mvn --batch-mode versions:set -DgenerateBackupPoms=false -DnewVersion=${VERSION}
     - name: mvn deploy


### PR DESCRIPTION
* replaced unsecure stdout based ::set-env workflow command with save file system based version
* change allows this workflow to run after upcoming deprecation of stdout based command this month (November 2020)

### Sources: 
* [Google Project Zero vulnerability report](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w)
 * [GitHub ::set-env deprecation notes](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)
* [migration advice followed in this PR](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)
