### PR TITLE
Add LabId and allow DOB-Hashes

### DIFF
--- a/src/main/java/app/coronawarn/testresult/entity/TestResultEntity.java
+++ b/src/main/java/app/coronawarn/testresult/entity/TestResultEntity.java
@@ -68,6 +68,9 @@ public class TestResultEntity {
   @Column(name = "result_date")
   private LocalDateTime resultDate;
 
+  @Column(name = "lab_id")
+  private String labId;
+
   public TestResultEntity setResult(Integer result) {
     this.result = result;
     return this;
@@ -80,6 +83,11 @@ public class TestResultEntity {
 
   public TestResultEntity setResultDate(LocalDateTime resultDate) {
     this.resultDate = resultDate;
+    return this;
+  }
+
+  public TestResultEntity setLabId(String labId) {
+    this.labId = labId;
     return this;
   }
 

--- a/src/main/java/app/coronawarn/testresult/model/QuickTestResult.java
+++ b/src/main/java/app/coronawarn/testresult/model/QuickTestResult.java
@@ -29,7 +29,9 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
 /**
  * Model of the test result.
@@ -38,8 +40,10 @@ import lombok.ToString;
   description = "The test result model."
 )
 @Getter
+@Setter
 @ToString
 @EqualsAndHashCode
+@Accessors(chain = true)
 public class QuickTestResult {
 
   /**
@@ -66,19 +70,4 @@ public class QuickTestResult {
    * Timestamp of the SampleCollection (sc).
    */
   private Long sc;
-
-  public QuickTestResult setId(String id) {
-    this.id = id;
-    return this;
-  }
-
-  public QuickTestResult setResult(Integer result) {
-    this.result = result;
-    return this;
-  }
-
-  public QuickTestResult setSampleCollection(Long sc) {
-    this.sc = sc;
-    return this;
-  }
 }

--- a/src/main/java/app/coronawarn/testresult/model/QuickTestResult.java
+++ b/src/main/java/app/coronawarn/testresult/model/QuickTestResult.java
@@ -50,7 +50,7 @@ public class QuickTestResult {
    * Hash (SHA256) of test result id (aka QR-Code, GUID) encoded as hex string.
    */
   @NotBlank
-  @Pattern(regexp = "^([A-Fa-f0-9]{2}){32}$")
+  @Pattern(regexp = "^[XxA-Fa-f0-9]([A-Fa-f0-9]{63})$")
   private String id;
 
   /**

--- a/src/main/java/app/coronawarn/testresult/model/QuickTestResultList.java
+++ b/src/main/java/app/coronawarn/testresult/model/QuickTestResultList.java
@@ -21,6 +21,7 @@
 
 package app.coronawarn.testresult.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import javax.validation.Valid;
@@ -28,7 +29,9 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
 /**
  * Model of the test result list.
@@ -37,8 +40,10 @@ import lombok.ToString;
   description = "The test result list model."
 )
 @Getter
+@Setter
 @ToString
 @EqualsAndHashCode
+@Accessors(chain = true)
 public class QuickTestResultList {
 
   /**
@@ -48,8 +53,9 @@ public class QuickTestResultList {
   @NotEmpty
   private List<@Valid QuickTestResult> testResults;
 
-  public QuickTestResultList setTestResults(List<QuickTestResult> testResults) {
-    this.testResults = testResults;
-    return this;
-  }
+  /**
+   * The labId of the uploader.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String labId;
 }

--- a/src/main/java/app/coronawarn/testresult/model/TestResult.java
+++ b/src/main/java/app/coronawarn/testresult/model/TestResult.java
@@ -51,7 +51,7 @@ public class TestResult {
    * Hash (SHA256) of test result id (aka QR-Code, GUID) encoded as hex string.
    */
   @NotBlank
-  @Pattern(regexp = "^([A-Fa-f0-9]{2}){32}$")
+  @Pattern(regexp = "^[XxA-Fa-f0-9]([A-Fa-f0-9]{63})$")
   private String id;
 
   /**

--- a/src/main/java/app/coronawarn/testresult/model/TestResult.java
+++ b/src/main/java/app/coronawarn/testresult/model/TestResult.java
@@ -21,6 +21,7 @@
 
 package app.coronawarn.testresult.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -29,8 +30,9 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NonNull;
+import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
 /**
  * Model of the test result.
@@ -39,8 +41,10 @@ import lombok.ToString;
   description = "The test result model."
 )
 @Getter
+@Setter
 @ToString
 @EqualsAndHashCode
+@Accessors(chain = true)
 public class TestResult {
 
   /**
@@ -72,18 +76,6 @@ public class TestResult {
    */
   private Long sc;
 
-  public TestResult setId(String id) {
-    this.id = id;
-    return this;
-  }
-
-  public TestResult setResult(Integer result) {
-    this.result = result;
-    return this;
-  }
-
-  public TestResult setSampleCollection(Long sc) {
-    this.sc = sc;
-    return this;
-  }
+  @JsonIgnore
+  private String labId;
 }

--- a/src/main/java/app/coronawarn/testresult/model/TestResultList.java
+++ b/src/main/java/app/coronawarn/testresult/model/TestResultList.java
@@ -21,6 +21,7 @@
 
 package app.coronawarn.testresult.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import javax.validation.Valid;
@@ -28,7 +29,9 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
 /**
  * Model of the test result list.
@@ -37,8 +40,10 @@ import lombok.ToString;
   description = "The test result list model."
 )
 @Getter
+@Setter
 @ToString
 @EqualsAndHashCode
+@Accessors(chain = true)
 public class TestResultList {
 
   /**
@@ -48,8 +53,10 @@ public class TestResultList {
   @NotEmpty
   private List<@Valid TestResult> testResults;
 
-  public TestResultList setTestResults(List<TestResult> testResults) {
-    this.testResults = testResults;
-    return this;
-  }
+  /**
+   * The labId of the uploader.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String labId;
+
 }

--- a/src/main/java/app/coronawarn/testresult/model/TestResultRequest.java
+++ b/src/main/java/app/coronawarn/testresult/model/TestResultRequest.java
@@ -43,7 +43,7 @@ public class TestResultRequest {
    * Hash (SHA256) of test result id (aka QR-Code, GUID) encoded as hex string.
    */
   @NotBlank
-  @Pattern(regexp = "^([A-Fa-f0-9]{2}){32}$")
+  @Pattern(regexp = "^[XxA-Fa-f0-9]([A-Fa-f0-9]{63})$")
   private String id;
 
   /**

--- a/src/main/java/app/coronawarn/testresult/model/TestResultResponse.java
+++ b/src/main/java/app/coronawarn/testresult/model/TestResultResponse.java
@@ -23,13 +23,14 @@ package app.coronawarn.testresult.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
-import javax.annotation.Nullable;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
 /**
  * Response model of the test result.
@@ -41,6 +42,7 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Accessors(chain = true)
 public class TestResultResponse {
 
   /**
@@ -64,6 +66,12 @@ public class TestResultResponse {
    * Timestamp of the SampleCollection (sc).
    */
   private Long sc;
+
+  /**
+   * LabId of the lab that executed the test.
+   */
+  @Setter
+  private String labId;
 
   /**
    * Default constructor with sc null.

--- a/src/main/java/app/coronawarn/testresult/service/TestResultService.java
+++ b/src/main/java/app/coronawarn/testresult/service/TestResultService.java
@@ -53,7 +53,8 @@ public class TestResultService {
     return new TestResult()
       .setId(entity.getResultId())
       .setResult(entity.getResult())
-      .setSampleCollection(entity.getResultDate().atZone(ZoneId.of("UTC")).toEpochSecond());
+      .setSc(entity.getResultDate().atZone(ZoneId.of("UTC")).toEpochSecond())
+      .setLabId(entity.getLabId());
   }
 
   /**
@@ -65,12 +66,13 @@ public class TestResultService {
    */
   public TestResultEntity toEntity(TestResult model) {
     if (model.getSc() == null) {
-      model.setSampleCollection(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
+      model.setSc(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC));
     }
     return new TestResultEntity()
       .setResult(model.getResult())
       .setResultId(model.getId())
-      .setResultDate(LocalDateTime.ofEpochSecond(model.getSc(), 0, ZoneOffset.UTC));
+      .setResultDate(LocalDateTime.ofEpochSecond(model.getSc(), 0, ZoneOffset.UTC))
+      .setLabId(model.getLabId());
   }
 
   /**
@@ -97,6 +99,7 @@ public class TestResultService {
         }
         entity.setResult(result.getResult())
           .setResultDate(sc);
+        entity.setLabId(result.getLabId());
         entity = testResultRepository.save(entity);
       }
       return toModel(entity);
@@ -147,9 +150,10 @@ public class TestResultService {
    * @param quickTestResult the Result to convert
    * @return the converted test result
    */
-  public TestResult convertQuickTest(QuickTestResult quickTestResult) {
+  public TestResult convertQuickTest(QuickTestResult quickTestResult, String labId) {
     TestResult testResult = new TestResult();
     testResult.setResult(quickTestResult.getResult());
+    testResult.setLabId(labId);
     testResult.setId(hashingService.sha256Hash(quickTestResult.getId()));
     return testResult;
   }

--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -8,3 +8,6 @@ databaseChangeLog:
 - include:
     file: changelog/v002-revert-test-result-result-nullable.yml
     relativeToChangelogFile: true
+- include:
+    file: changelog/v003-add-labid-column.yml
+    relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/v003-add-labid-column.yml
+++ b/src/main/resources/db/changelog/v003-add-labid-column.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+- changeSet:
+    id: add-lab-id-column
+    author: f11h
+    changes:
+    - addColumn:
+        tableName: test_result
+        columns:
+          name: lab_id
+          type: varchar(64)
+          constraints:
+            nullable: true

--- a/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
@@ -150,6 +150,27 @@ public class TestResultControllerTest {
   }
 
   @Test
+  public void insertValidDobHashShouldReturnNoContentWithLabId() throws Exception {
+    // data
+    String id = "x" + "b".repeat(63);
+    String labId = "l".repeat(64);
+    Integer result = 1;
+    // create
+    TestResultList valid = new TestResultList()
+      .setLabId(labId)
+      .setTestResults(Collections.singletonList(
+        new TestResult().setId(id).setResult(result)
+      ));
+    mockMvc.perform(MockMvcRequestBuilders
+      .post("/api/v1/lab/results")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+      .contentType(MediaType.APPLICATION_JSON_VALUE)
+      .content(objectMapper.writeValueAsString(valid)))
+      .andDo(MockMvcResultHandlers.print())
+      .andExpect(MockMvcResultMatchers.status().isNoContent());
+  }
+
+  @Test
   public void insertValidAndGetShouldReturnOkWithoutLabId() throws Exception {
     // data
     String id = "c".repeat(64);
@@ -237,6 +258,25 @@ public class TestResultControllerTest {
   public void quickInsertValidWithCsShouldReturnNoContent() throws Exception {
     // data
     String id = "b".repeat(64);
+    Integer result = 5;
+    // create
+    QuickTestResultList valid = new QuickTestResultList();
+    valid.setTestResults(Collections.singletonList(
+      new QuickTestResult().setId(id).setResult(result).setSc(System.currentTimeMillis())
+    ));
+    mockMvc.perform(MockMvcRequestBuilders
+      .post("/api/v1/quicktest/results")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+      .contentType(MediaType.APPLICATION_JSON_VALUE)
+      .content(objectMapper.writeValueAsString(valid)))
+      .andDo(MockMvcResultHandlers.print())
+      .andExpect(MockMvcResultMatchers.status().isNoContent());
+  }
+
+  @Test
+  public void quickInsertValidWithDobHashAndWithCsShouldReturnNoContent() throws Exception {
+    // data
+    String id = "x" + "b".repeat(63);
     Integer result = 5;
     // create
     QuickTestResultList valid = new QuickTestResultList();

--- a/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultControllerTest.java
@@ -21,7 +21,14 @@
 
 package app.coronawarn.testresult;
 
-import app.coronawarn.testresult.model.*;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import app.coronawarn.testresult.model.QuickTestResult;
+import app.coronawarn.testresult.model.QuickTestResultList;
+import app.coronawarn.testresult.model.TestResult;
+import app.coronawarn.testresult.model.TestResultList;
+import app.coronawarn.testresult.model.TestResultRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
@@ -104,7 +111,7 @@ public class TestResultControllerTest {
   }
 
   @Test
-  public void insertValidShouldReturnNoContent() throws Exception {
+  public void insertValidShouldReturnNoContentWithoutLabId() throws Exception {
     // data
     String id = "b".repeat(64);
     Integer result = 1;
@@ -122,7 +129,28 @@ public class TestResultControllerTest {
   }
 
   @Test
-  public void insertValidAndGetShouldReturnOk() throws Exception {
+  public void insertValidShouldReturnNoContentWithLabId() throws Exception {
+    // data
+    String id = "b".repeat(64);
+    String labId = "l".repeat(64);
+    Integer result = 1;
+    // create
+    TestResultList valid = new TestResultList()
+      .setLabId(labId)
+      .setTestResults(Collections.singletonList(
+      new TestResult().setId(id).setResult(result)
+    ));
+    mockMvc.perform(MockMvcRequestBuilders
+      .post("/api/v1/lab/results")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+      .contentType(MediaType.APPLICATION_JSON_VALUE)
+      .content(objectMapper.writeValueAsString(valid)))
+      .andDo(MockMvcResultHandlers.print())
+      .andExpect(MockMvcResultMatchers.status().isNoContent());
+  }
+
+  @Test
+  public void insertValidAndGetShouldReturnOkWithoutLabId() throws Exception {
     // data
     String id = "c".repeat(64);
     Integer result = 1;
@@ -146,7 +174,41 @@ public class TestResultControllerTest {
       .contentType(MediaType.APPLICATION_JSON_VALUE)
       .content(objectMapper.writeValueAsString(request)))
       .andDo(MockMvcResultHandlers.print())
-      .andExpect(MockMvcResultMatchers.status().isOk());
+      .andExpect(MockMvcResultMatchers.status().isOk())
+      .andExpect(jsonPath("labId").doesNotExist());
+
+  }
+
+  @Test
+  public void insertValidAndGetShouldReturnOkWithLabId() throws Exception {
+    // data
+    String id = "c".repeat(64);
+    String labId = "l".repeat(64);
+    Integer result = 1;
+    // create
+    TestResultList valid = new TestResultList()
+      .setLabId(labId)
+      .setTestResults(Collections.singletonList(
+      new TestResult().setId(id).setResult(result)
+    ));
+    mockMvc.perform(MockMvcRequestBuilders
+      .post("/api/v1/lab/results")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+      .contentType(MediaType.APPLICATION_JSON_VALUE)
+      .content(objectMapper.writeValueAsString(valid)))
+      .andDo(MockMvcResultHandlers.print())
+      .andExpect(MockMvcResultMatchers.status().isNoContent());
+    // get
+    TestResultRequest request = new TestResultRequest()
+      .setId(id);
+    mockMvc.perform(MockMvcRequestBuilders
+      .post("/api/v1/app/result")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+      .contentType(MediaType.APPLICATION_JSON_VALUE)
+      .content(objectMapper.writeValueAsString(request)))
+      .andDo(MockMvcResultHandlers.print())
+      .andExpect(MockMvcResultMatchers.status().isOk())
+      .andExpect(jsonPath("labId", is(labId)));
   }
 
   @Test
@@ -178,8 +240,29 @@ public class TestResultControllerTest {
     Integer result = 5;
     // create
     QuickTestResultList valid = new QuickTestResultList();
-    valid.setTestResults( Collections.singletonList(
-      new QuickTestResult().setId(id).setResult(result).setSampleCollection(System.currentTimeMillis())
+    valid.setTestResults(Collections.singletonList(
+      new QuickTestResult().setId(id).setResult(result).setSc(System.currentTimeMillis())
+    ));
+    mockMvc.perform(MockMvcRequestBuilders
+      .post("/api/v1/quicktest/results")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+      .contentType(MediaType.APPLICATION_JSON_VALUE)
+      .content(objectMapper.writeValueAsString(valid)))
+      .andDo(MockMvcResultHandlers.print())
+      .andExpect(MockMvcResultMatchers.status().isNoContent());
+  }
+
+  @Test
+  public void quickInsertValidWithCsShouldReturnNoContentWithLabId() throws Exception {
+    // data
+    String id = "b".repeat(64);
+    String labId = "l".repeat(64);
+    Integer result = 5;
+    // create
+    QuickTestResultList valid = new QuickTestResultList();
+    valid.setLabId(labId);
+    valid.setTestResults(Collections.singletonList(
+      new QuickTestResult().setId(id).setResult(result).setSc(System.currentTimeMillis())
     ));
     mockMvc.perform(MockMvcRequestBuilders
       .post("/api/v1/quicktest/results")
@@ -198,7 +281,7 @@ public class TestResultControllerTest {
     // create
     QuickTestResultList valid = new QuickTestResultList();
     valid.setTestResults(Collections.singletonList(
-      new QuickTestResult().setId(id).setResult(result).setSampleCollection(System.currentTimeMillis())
+      new QuickTestResult().setId(id).setResult(result).setSc(System.currentTimeMillis())
     ));
     mockMvc.perform(MockMvcRequestBuilders
       .post("/api/v1/quicktest/results")
@@ -230,7 +313,7 @@ public class TestResultControllerTest {
     Integer result = 5;
     // create
     QuickTestResultList valid = new QuickTestResultList();
-    valid.setTestResults( Collections.singletonList(
+    valid.setTestResults(Collections.singletonList(
       new QuickTestResult().setId(id).setResult(result)
     ));
     mockMvc.perform(MockMvcRequestBuilders
@@ -249,7 +332,7 @@ public class TestResultControllerTest {
     Integer result = 4;
     // create
     QuickTestResultList valid = new QuickTestResultList();
-    valid.setTestResults( Collections.singletonList(
+    valid.setTestResults(Collections.singletonList(
       new QuickTestResult().setId(id).setResult(result)
     ));
     mockMvc.perform(MockMvcRequestBuilders

--- a/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
+++ b/src/test/java/app/coronawarn/testresult/TestResultServiceTest.java
@@ -54,68 +54,83 @@ public class TestResultServiceTest {
   public void toEntityAndToModel() {
     // data
     String id = "a".repeat(64);
+    String labId = "l".repeat(64);
     Integer result = 1;
     // to entity
     TestResult model = new TestResult()
       .setId(id)
+      .setLabId(labId)
       .setResult(result);
     TestResultEntity entity = testResultService.toEntity(model);
     Assert.assertNotNull(entity);
     Assert.assertEquals(id, entity.getResultId());
     Assert.assertEquals(result, entity.getResult());
+    Assert.assertEquals(labId, entity.getLabId());
     // to model
     model = testResultService.toModel(entity);
     Assert.assertNotNull(model);
     Assert.assertEquals(id, model.getId());
     Assert.assertEquals(result, model.getResult());
+    Assert.assertEquals(labId, model.getLabId());
   }
 
   @Test
   public void insertOrUpdate() {
     // data
     String id = "a".repeat(64);
+    String labId = "l".repeat(64);
     Integer result = 1;
     TestResult create = new TestResult()
       .setId(id)
-      .setResult(result);
+      .setResult(result)
+      .setLabId(labId);
     // create
     create = testResultService.createOrUpdate(create);
     Assert.assertNotNull(create);
     Assert.assertEquals(result, create.getResult());
+    Assert.assertEquals(labId, create.getLabId());
     // get
     TestResult get = testResultService.getOrCreate(id, false, 0L);
     Assert.assertNotNull(get);
     Assert.assertEquals(result, get.getResult());
+    Assert.assertEquals(labId, get.getLabId());
   }
 
   @Test
   public void insertAndUpdate() {
     // data
     String id = "a".repeat(64);
+    String labId = "l".repeat(64);
     Integer resultCreate = 1;
     Integer resultUpdate = 2;
     TestResult create = new TestResult()
       .setId(id)
-      .setResult(resultCreate);
+      .setResult(resultCreate)
+      .setLabId(labId);
     // create
     create = testResultService.createOrUpdate(create);
     Assert.assertNotNull(create);
     Assert.assertEquals(resultCreate, create.getResult());
+    Assert.assertEquals(labId, create.getLabId());
     // get
     TestResult get = testResultService.getOrCreate(id, false, 0L);
     Assert.assertNotNull(get);
     Assert.assertEquals(resultCreate, get.getResult());
+    Assert.assertEquals(labId, get.getLabId());
     // update
     TestResult update = new TestResult()
       .setId(id)
-      .setResult(resultUpdate);
+      .setResult(resultUpdate)
+      .setLabId(labId);
     update = testResultService.createOrUpdate(update);
     Assert.assertNotNull(update);
     Assert.assertEquals(resultUpdate, update.getResult());
+    Assert.assertEquals(labId, update.getLabId());
     // get
     get = testResultService.getOrCreate(id, false, 0L);
     Assert.assertNotNull(get);
     Assert.assertEquals(resultUpdate, get.getResult());
+    Assert.assertEquals(labId, get.getLabId());
   }
 
   @Test
@@ -127,6 +142,7 @@ public class TestResultServiceTest {
     TestResult get = testResultService.getOrCreate(id, false, 0L);
     Assert.assertNotNull(get);
     Assert.assertEquals(result, get.getResult());
+    Assert.assertNull(get.getLabId());
   }
 
   @Test


### PR DESCRIPTION
This PR adds support for LabID Parameter when uploading Testresults.
Also the LabId will be returned when a TR is requested.

In addition this PR adds the ability to up- and download TR for DOB-Hashes (Hashes starting with X/x)

This PR closes #99 