### PR TITLE
Chore: Update CWA-Parent to 1.4

### DIFF
--- a/owasp/suppressions.xml
+++ b/owasp/suppressions.xml
@@ -4,4 +4,19 @@
     <notes>Bug only affects not used features of embedded tomcat.</notes>
     <cve>CVE-2022-23181</cve>
   </suppress>
+
+  <suppress>
+    <notes>CVE is matching for Spring Security 5.3.x, but we have 5.7.x</notes>
+    <cve>CVE-2020-5408</cve>
+  </suppress>
+
+  <suppress>
+    <notes>CVE is matching for Spring Framework up to 5.3.20, but we have 5.3.21</notes>
+    <cve>CVE-2016-1000027</cve>
+  </suppress>
+
+  <suppress>
+    <notes>CVE warns about usage of sample code in Tomcat Repository. This code is not used by us.</notes>
+    <cve>CVE-2022-34305</cve>
+  </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>app.coronawarn</groupId>
     <artifactId>cwa-parent</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
### Update the parent pom (cwa-parent) to the last released version.
  
  This PR will update several dependencies within this project.
  Please do a full integration test before merging this PR.
  
  Also please have a look on the [Release Notes](https://github.com/corona-warn-app/cwa-parent/releases/tag/1.4) of this new CWA-Parent version.