### PR TITLE
Chore: Update CWA-Parent to 1.7

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -282,7 +282,7 @@
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>app.coronawarn</groupId>
     <artifactId>cwa-parent</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
     <relativePath/>
   </parent>
 

--- a/src/main/java/app/coronawarn/testresult/TestResultController.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultController.java
@@ -69,7 +69,7 @@ public class TestResultController {
         responseCode = "200",
         description = "Content exists",
         content = @Content(schema = @Schema(implementation = TestResultResponse.class))
-      )
+        )
     }
   )
   @PostMapping(
@@ -103,7 +103,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "204",
         description = "No content, testresult successfully inserted"
-      )
+        )
     }
   )
   @PostMapping(
@@ -137,7 +137,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "200",
         description = "Ok, RAT result inserted successfully."
-      )
+        )
     }
   )
   @PostMapping(
@@ -169,7 +169,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "204",
         description = "No content, RAT result(s) inserted successfully."
-      )
+        )
     }
   )
   @PostMapping(
@@ -203,7 +203,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "200",
         description = "Ok, PoC-NAT result inserted successfully."
-      )
+        )
     }
   )
   @PostMapping(
@@ -235,7 +235,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "204",
         description = "No content, PoC-NAT result(s) inserted successfully."
-      )
+        )
     }
   )
   @PostMapping(

--- a/src/main/java/app/coronawarn/testresult/TestResultController.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultController.java
@@ -21,7 +21,6 @@
 
 package app.coronawarn.testresult;
 
-import app.coronawarn.testresult.model.PocNatResult;
 import app.coronawarn.testresult.model.PocNatResultList;
 import app.coronawarn.testresult.model.QuickTestResultList;
 import app.coronawarn.testresult.model.TestResult;


### PR DESCRIPTION
### Update the parent pom (cwa-parent) to the last released version.
  
  This PR will update several dependencies within this project.
  Please do a full integration test before merging this PR.
  
  Also please have a look on the [Release Notes](https://github.com/corona-warn-app/cwa-parent/releases/tag/1.7) of this new CWA-Parent version.