### PR TITLE
Chore: Update CWA-Parent to 1.7.1

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -282,7 +282,7 @@
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/owasp/suppressions.xml
+++ b/owasp/suppressions.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
   <suppress>
-    <notes>Bug only affects not used features of embedded tomcat.</notes>
-    <cve>CVE-2022-23181</cve>
+    <notes>Updating of Keycloak Lib is not possible at the moment. Security risk is not affecting CWA components.</notes>
+    <cve>CVE-2022-1466</cve>
+    <cve>CVE-2022-1970</cve>
+    <cve>CVE-2021-20323</cve>
+    <cve>CVE-2020-14359</cve>
   </suppress>
 
   <suppress>
@@ -16,17 +20,21 @@
   </suppress>
 
   <suppress>
-    <notes>CVE warns about usage of sample code in Tomcat Repository. This code is not used by us.</notes>
-    <cve>CVE-2022-34305</cve>
-  </suppress>
-
-  <suppress>
-    <notes>False Positive</notes>
+    <notes>False Positive matches</notes>
     <cve>CVE-2022-31514</cve>
-  </suppress>
-
-  <suppress>
-    <notes>False Positive (https://github.com/jeremylong/DependencyCheck/issues/4693)</notes>
     <cve>CVE-2022-2393</cve>
   </suppress>
+
+  <suppress>
+    <notes>Keycloak Update is currently not possible</notes>
+    <cve>CVE-2022-1245</cve>
+    <cve>CVE-2022-2668</cve>
+    <cve>CVE-2021-3827</cve>
+  </suppress>
+
+  <suppress>
+    <notes>SnakeYML False Positive Matcher (CVE is up to 1.32, but also matches for 1.33)</notes>
+    <cve>CVE-2022-38752</cve>
+  </suppress>
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>app.coronawarn</groupId>
     <artifactId>cwa-parent</artifactId>
-    <version>1.6</version>
+    <version>1.7.1</version>
     <relativePath/>
   </parent>
 

--- a/src/main/java/app/coronawarn/testresult/TestResultController.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultController.java
@@ -68,7 +68,7 @@ public class TestResultController {
         responseCode = "200",
         description = "Content exists",
         content = @Content(schema = @Schema(implementation = TestResultResponse.class))
-      )
+        )
     }
   )
   @PostMapping(
@@ -102,7 +102,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "204",
         description = "No content, testresult successfully inserted"
-      )
+        )
     }
   )
   @PostMapping(
@@ -136,7 +136,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "200",
         description = "Ok, RAT result inserted successfully."
-      )
+        )
     }
   )
   @PostMapping(
@@ -168,7 +168,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "204",
         description = "No content, RAT result(s) inserted successfully."
-      )
+        )
     }
   )
   @PostMapping(
@@ -202,7 +202,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "200",
         description = "Ok, PoC-NAT result inserted successfully."
-      )
+        )
     }
   )
   @PostMapping(
@@ -234,7 +234,7 @@ public class TestResultController {
       @ApiResponse(
         responseCode = "204",
         description = "No content, PoC-NAT result(s) inserted successfully."
-      )
+        )
     }
   )
   @PostMapping(

--- a/src/main/java/app/coronawarn/testresult/TestResultController.java
+++ b/src/main/java/app/coronawarn/testresult/TestResultController.java
@@ -21,7 +21,6 @@
 
 package app.coronawarn.testresult;
 
-import app.coronawarn.testresult.model.PocNatResult;
 import app.coronawarn.testresult.model.PocNatResultList;
 import app.coronawarn.testresult.model.QuickTestResultList;
 import app.coronawarn.testresult.model.TestResult;


### PR DESCRIPTION
### Update the parent pom (cwa-parent) to the last released version.
  
  This PR will update several dependencies within this project.
  Please do a full integration test before merging this PR.
  
  Also please have a look on the [Release Notes](https://github.com/corona-warn-app/cwa-parent/releases/tag/1.7.1) of this new CWA-Parent version.